### PR TITLE
Fix rule for space after functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.2]
+### Changed
+* `space-after-function-paren` rule. Specifying `always` for `anonymous functions` and `never` for `named functions`
+
 ## [1.0.1]
 ### Fixed
 * `space-after-function-name` is deprecated. Using `space-before-function-paren` instead

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -11,6 +11,8 @@
     "semi-spacing": [2, { "before": false, "after": false }],
     "camelcase": 0,
     "object-curly-spacing": [2, "always"],
-    "space-before-function-paren": [2, "never"]
+    "space-before-function-paren": [
+      2, { "anonymous": "always", "named": "never" }
+    ]
   }
 }


### PR DESCRIPTION
Basado en la [doc de eslint](http://eslint.org/docs/rules/space-before-function-paren), podemos usar la siguiente config:

```
["error", { "anonymous": "always", "named": "never" }]
```

I va a hintear este code como problemas:

```
function foo () {
    // ...
}

var bar = function() {
    // ...
};
```
