### PR TITLE
add rules for spacing and quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+* Rule for quotes in jsx attributes
+* Rule for spacing in parenthesis within jsx attributes
+
 ## [1.0.2]
 ### Changed
 * `space-after-function-paren` rule. Specifying `always` for `anonymous functions` and `never` for `named functions`

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -13,6 +13,8 @@
     "object-curly-spacing": [2, "always"],
     "space-before-function-paren": [
       2, { "anonymous": "always", "named": "never" }
-    ]
+    ],
+    "jsx-quotes": [2, "prefer-double"],
+    "react/jsx-curly-spacing": [2, "always"]
   }
 }


### PR DESCRIPTION
I haven't test this in hashdard because I'm not sure how to use a custom config to test it (as they're fetch from the package.json I suppose).

[jsx-quotes](http://eslint.org/docs/rules/jsx-quotes) allows to lint this as error:

``` jsx
<a b='c' />
<b c="d" /> // this is fine
```

The other rule I added is [jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md), this rule lints the following as an error:

``` jsx
<Component
  foo={prop1}
  bar={ prop2}
/>

<Component
  foo={ prop1 } // this is fine
/>
```

However, as mentioned [here](https://github.com/yannickcr/eslint-plugin-react/issues/857) the rule does not work for:

``` jsx
<Component>
  {something}
</Component>
```
### Screenshots

![image](https://cloud.githubusercontent.com/assets/4183514/19653669/60bf50ac-99e3-11e6-97c8-3b8cbb0a912c.png)

![image](https://cloud.githubusercontent.com/assets/4183514/19653675/66f15830-99e3-11e6-9714-fe94bdd5092e.png)
